### PR TITLE
Add batch sync to gate action

### DIFF
--- a/src/app/features/members-list/members-list.component.html
+++ b/src/app/features/members-list/members-list.component.html
@@ -13,6 +13,18 @@
       >
         {{ t("EXPORT") }}
       </button>
+      @if(allowSync()){
+      <button
+        *appHasRole="['SuperAdmin', 'SalesManager']"
+        mat-stroked-button
+        class="mb-2 me-3"
+        color="primary"
+        type="button"
+        (click)="batchSyncToGate()"
+      >
+        {{ t("ADD_TO_GATE") }}
+      </button>
+      }
       <button
         mat-flat-button
         class="mb-2 me-3 me-sm-0"

--- a/src/app/features/members-list/members-list.component.ts
+++ b/src/app/features/members-list/members-list.component.ts
@@ -1,4 +1,7 @@
-import { Component } from "@angular/core";
+import { Component, computed, inject } from "@angular/core";
+import { UserMembershipService } from "./services/user-membership.service";
+import { SnackbarService } from "../../core/services/snackbar/snackbar.service";
+import { BranchesService } from "../../core/services/branches/branches.service";
 import { MemberFilterComponent } from "./components/member-filter/member-filter.component";
 import { EmptyResultComponent } from "../../shared/ui-components/templates/empty-result/empty-result.component";
 import { MatButtonModule } from "@angular/material/button";
@@ -36,4 +39,21 @@ import { HasRoleDirective } from "../../core/directives/has-role.directive";
 export class MembersListComponent {
   translationTemplate = TranslationTemplates.MEMBER;
   APP_ROUTES = APP_ROUTES;
+
+  private userMembershipService = inject(UserMembershipService);
+  private snackbarService = inject(SnackbarService);
+  private branchesService = inject(BranchesService);
+
+  allowSync = computed(() => !!this.branchesService.value().allowScan);
+
+  batchSyncToGate() {
+    const branchId = this.branchesService.value().id;
+    if (!branchId) {
+      return;
+    }
+    this.userMembershipService.batchSyncToGate(branchId).subscribe({
+      next: () => this.snackbarService.success('BATCH_SYNC_SUCCESS'),
+      error: () => this.snackbarService.error('BATCH_SYNC_ERROR'),
+    });
+  }
 }

--- a/src/app/features/members-list/services/user-membership.service.ts
+++ b/src/app/features/members-list/services/user-membership.service.ts
@@ -155,6 +155,17 @@ export class UserMembershipService {
   }
 
   /**
+   * Sync all memberships of the current branch to the gate system.
+   * @param branchId Identifier of the branch whose memberships will be synced.
+   * @returns Observable with the sync result.
+   */
+  batchSyncToGate(branchId: string): Observable<any> {
+    return this.http.post<any>(`api/batch-synct-to-gate`, {
+      branchId,
+    });
+  }
+
+  /**
    * Delete a user membership record by ID.
    * @param id The user mu ID.
    * @returns Observable with the deletion result.

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -182,6 +182,8 @@
     "IN_ACTIVE": "Inactive",
     "TD_NOT_ACTIVE": "Expired",
     "ADD_TO_GATE": "Sync to Gate",
+    "BATCH_SYNC_SUCCESS": "Synced Members to Gate Successfully",
+    "BATCH_SYNC_ERROR": "Error Syncing Members to Gate",
     "DEDUCT_VISIT": "Deduct Visit",
     "CONFIRM_DEDUCT_VISIT_MEMBERSHIP_OVERLAY_HEDER": "Deduct Visit",
     "CONFIRM_DEDUCT_VISIT_MEMBERSHIP_OVERLAY_CONTENT" : "Are sure you want to deduct visit from this membership?"


### PR DESCRIPTION
## Summary
- add `batchSyncToGate` with branch id parameter
- show sync button only if current branch allows scanning
- include branch id when syncing from members list

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684044291e008326a3db98e6219e6919